### PR TITLE
Version 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 * SkyLib
 * SkyShop
 * Vault
+## Soft Dependencies
+* BentoBox
+* WorldGuard
+* QuickShop-Hikari
 ## Commands
 - /skysellwand - Command to open the shop.
   - Alias:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = "com.github.lukesky19"
-version = "1.1.0"
+version = "1.2.0"
 
 repositories {
     mavenCentral()
@@ -16,6 +16,10 @@ repositories {
         name = "jitpack"
     }
 
+    maven("https://repo.codemc.org/repository/maven-public/")
+
+    maven("https://maven.enginehub.org/repo/")
+
     mavenLocal()
 }
 
@@ -24,6 +28,11 @@ dependencies {
     compileOnly("com.github.MilkBowl:VaultAPI:1.7")
     compileOnly("com.github.lukesky19:SkyLib:1.1.0")
     compileOnly("com.github.lukesky19:SkyShop:2.0.0-Pre-Release-2")
+
+    // Hooks
+    compileOnly("dev.rosewood:rosestacker:1.5.30")
+    compileOnly("world.bentobox:bentobox:2.6.0-SNAPSHOT")
+    compileOnly("com.sk89q.worldguard:worldguard-bukkit:7.0.11")
 }
 
 java {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     compileOnly("io.papermc.paper:paper-api:1.21-R0.1-SNAPSHOT")
     compileOnly("com.github.MilkBowl:VaultAPI:1.7")
     compileOnly("com.github.lukesky19:SkyLib:1.1.0")
-    compileOnly("com.github.lukesky19:SkyShop:2.0.0-Pre-Release-2")
+    compileOnly("com.github.lukesky19:SkyShop:2.0.0-Pre-Release-3")
 
     // Hooks
     compileOnly("world.bentobox:bentobox:2.6.0-SNAPSHOT")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,8 @@ dependencies {
     compileOnly("dev.rosewood:rosestacker:1.5.30")
     compileOnly("world.bentobox:bentobox:2.6.0-SNAPSHOT")
     compileOnly("com.sk89q.worldguard:worldguard-bukkit:7.0.11")
+    compileOnly("com.ghostchu:quickshop-api:6.2.0.6")
+
 }
 
 java {

--- a/src/main/java/com/github/lukesky19/skySellWands/SkySellWands.java
+++ b/src/main/java/com/github/lukesky19/skySellWands/SkySellWands.java
@@ -21,6 +21,7 @@ import com.github.lukesky19.skySellWands.command.SellWandCommand;
 import com.github.lukesky19.skySellWands.configuration.manager.LocaleManager;
 import com.github.lukesky19.skySellWands.configuration.manager.SettingsManager;
 import com.github.lukesky19.skySellWands.listener.PlayerClickListener;
+import com.github.lukesky19.skySellWands.listener.ShopCreationListener;
 import com.github.lukesky19.skySellWands.manager.HookManager;
 import com.github.lukesky19.skySellWands.manager.WandManager;
 import com.github.lukesky19.skylib.format.FormatUtil;
@@ -62,6 +63,7 @@ public final class SkySellWands extends JavaPlugin {
 
         // Register Listener
         this.getServer().getPluginManager().registerEvents(playerClickListener, this);
+        this.getServer().getPluginManager().registerEvents(new ShopCreationListener(), this);
 
         // Register Command Executor and TabCompleter
         PluginCommand skySellWands = this.getServer().getPluginCommand("skysellwands");

--- a/src/main/java/com/github/lukesky19/skySellWands/SkySellWands.java
+++ b/src/main/java/com/github/lukesky19/skySellWands/SkySellWands.java
@@ -21,6 +21,7 @@ import com.github.lukesky19.skySellWands.command.SellWandCommand;
 import com.github.lukesky19.skySellWands.configuration.manager.LocaleManager;
 import com.github.lukesky19.skySellWands.configuration.manager.SettingsManager;
 import com.github.lukesky19.skySellWands.listener.PlayerClickListener;
+import com.github.lukesky19.skySellWands.manager.HookManager;
 import com.github.lukesky19.skySellWands.manager.WandManager;
 import com.github.lukesky19.skylib.format.FormatUtil;
 import com.github.lukesky19.skyshop.SkyShopAPI;
@@ -33,6 +34,7 @@ import org.jetbrains.annotations.Nullable;
 public final class SkySellWands extends JavaPlugin {
     private SettingsManager settingsManager;
     private LocaleManager localeManager;
+    private HookManager hookManager;
     private SkyShopAPI skyShopAPI;
     private Economy economy;
 
@@ -51,10 +53,11 @@ public final class SkySellWands extends JavaPlugin {
         setupSkyShopAPI();
 
         // Create class instances
+        hookManager = new HookManager(this);
         settingsManager = new SettingsManager(this);
         localeManager = new LocaleManager(this, settingsManager);
         WandManager wandManager = new WandManager(settingsManager, localeManager);
-        PlayerClickListener playerClickListener = new PlayerClickListener(this, settingsManager, localeManager);
+        PlayerClickListener playerClickListener = new PlayerClickListener(this, settingsManager, localeManager, hookManager);
         SellWandCommand sellWandCommand = new SellWandCommand(this, localeManager, wandManager);
 
         // Register Listener
@@ -77,6 +80,7 @@ public final class SkySellWands extends JavaPlugin {
     public void reload() {
         settingsManager.reload();
         localeManager.reload();
+        hookManager.reload();
     }
 
     /**

--- a/src/main/java/com/github/lukesky19/skySellWands/SkySellWands.java
+++ b/src/main/java/com/github/lukesky19/skySellWands/SkySellWands.java
@@ -20,6 +20,7 @@ package com.github.lukesky19.skySellWands;
 import com.github.lukesky19.skySellWands.command.SellWandCommand;
 import com.github.lukesky19.skySellWands.configuration.manager.LocaleManager;
 import com.github.lukesky19.skySellWands.configuration.manager.SettingsManager;
+import com.github.lukesky19.skySellWands.listener.ItemSoldListener;
 import com.github.lukesky19.skySellWands.listener.PlayerClickListener;
 import com.github.lukesky19.skySellWands.listener.ShopCreationListener;
 import com.github.lukesky19.skySellWands.manager.HookManager;
@@ -64,6 +65,7 @@ public final class SkySellWands extends JavaPlugin {
         // Register Listener
         this.getServer().getPluginManager().registerEvents(playerClickListener, this);
         this.getServer().getPluginManager().registerEvents(new ShopCreationListener(), this);
+        this.getServer().getPluginManager().registerEvents(new ItemSoldListener(), this);
 
         // Register Command Executor and TabCompleter
         PluginCommand skySellWands = this.getServer().getPluginCommand("skysellwands");

--- a/src/main/java/com/github/lukesky19/skySellWands/configuration/manager/LocaleManager.java
+++ b/src/main/java/com/github/lukesky19/skySellWands/configuration/manager/LocaleManager.java
@@ -37,7 +37,7 @@ public class LocaleManager {
 
     Locale locale;
     private final Locale DEFAULT_LOCALE = new Locale(
-            "1.1.0",
+            "1.2.0",
             "<aqua><bold>SkySellWands</bold></aqua><gray> ▪ </gray>",
             List.of(
                     "<aqua>SkySellWands is developed by <white><bold>lukeskywlker19</bold></white>.</aqua>",
@@ -57,7 +57,8 @@ public class LocaleManager {
             "<white>Sold all items in the container. Balance: <yellow><bal></yellow></white>",
             "<red>No items were sold as the container's inventory is empty.</red>",
             "<red>No items were sold as the container's inventory contained no items that could be sold.</red>",
-            "<dark_purple>POOF!</dark_purple> <red>Your sellwand ran out of uses.</red>");
+            "<dark_purple>POOF!</dark_purple> <red>Your sellwand ran out of uses.</red>",
+            "<red>You do not have access to this container to sell the items inside.</red>");
 
     /**
      * Constructor
@@ -140,7 +141,8 @@ public class LocaleManager {
                 || locale.sellSuccess() == null
                 || locale.containerInventoryEmpty() == null
                 || locale.noItemsSold() == null
-                || locale.wandUsedUp() == null) {
+                || locale.wandUsedUp() == null
+                || locale.noAccess() == null) {
             locale = null;
 
             logger.warn(FormatUtil.format("<yellow>Your locale configuration is invalid. The plugin will use an internal locale instead."));
@@ -151,8 +153,30 @@ public class LocaleManager {
         if(locale == null) return;
 
         switch(locale.configVersion()) {
+            case "1.2.0" -> {
+                // Current version, do nothing
+            }
+
             case "1.1.0" -> {
                 // Current version, do nothing
+                locale = new Locale(
+                        "1.2.0",
+                        locale.prefix(),
+                        locale.help(),
+                        locale.noPermission(),
+                        locale.unknownArgument(),
+                        locale.configReload(),
+                        locale.invalidPlayer(),
+                        locale.invalidUses(),
+                        locale.invalidAmount(),
+                        locale.givenWand(),
+                        locale.sellSuccess(),
+                        locale.containerInventoryEmpty(),
+                        locale.noItemsSold(),
+                        locale.wandUsedUp(),
+                        "<red>You do not have access to this container to sell the items inside.</red>");
+
+                saveLocale(locale);
             }
 
             case "1.0.0" -> {
@@ -162,7 +186,7 @@ public class LocaleManager {
                         "<yellow><# of uses | unlimited | infinite | inf></yellow> <yellow><amount></yellow></white>");
 
                 locale = new Locale(
-                        "1.1.0",
+                        "1.2.0",
                         locale.prefix(), help,
                         locale.noPermission(),
                         locale.unknownArgument(),
@@ -174,7 +198,8 @@ public class LocaleManager {
                         locale.sellSuccess(),
                         locale.containerInventoryEmpty(),
                         locale.noItemsSold(),
-                        locale.wandUsedUp());
+                        locale.wandUsedUp(),
+                        "<red>You do not have access to this container to sell the items inside.</red>");
 
                 saveLocale(locale);
             }

--- a/src/main/java/com/github/lukesky19/skySellWands/hooks/BentoBoxHook.java
+++ b/src/main/java/com/github/lukesky19/skySellWands/hooks/BentoBoxHook.java
@@ -1,0 +1,39 @@
+/*
+    SkyHoppers adds upgradable hoppers that can suction items, transfer items wirelessly to linked containers.
+    Copyright (C) 2024  lukeskywlker19
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package com.github.lukesky19.skySellWands.hooks;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import world.bentobox.bentobox.BentoBox;
+import world.bentobox.bentobox.api.user.User;
+import world.bentobox.bentobox.database.objects.Island;
+import world.bentobox.bentobox.lists.Flags;
+
+import java.util.Optional;
+
+public class BentoBoxHook implements ProtectionHook {
+    @Override
+    public boolean canPlayerOpen(Player player, Location location) {
+        Optional<Island> optionalIsland = BentoBox.getInstance().getIslands().getIslandAt(location);
+        if (optionalIsland.isEmpty()) return true;
+
+        Island island = optionalIsland.orElseThrow();
+        User user = BentoBox.getInstance().getPlayers().getUser(player.getUniqueId());
+        return island.isAllowed(user, Flags.CONTAINER);
+    }
+}

--- a/src/main/java/com/github/lukesky19/skySellWands/hooks/ProtectionHook.java
+++ b/src/main/java/com/github/lukesky19/skySellWands/hooks/ProtectionHook.java
@@ -1,5 +1,5 @@
 /*
-    SkySellWands adds sell wands that uses SkyShop's API selling.
+    SkyHoppers adds upgradable hoppers that can suction items, transfer items wirelessly to linked containers.
     Copyright (C) 2024  lukeskywlker19
 
     This program is free software: you can redistribute it and/or modify
@@ -15,23 +15,17 @@
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
-package com.github.lukesky19.skySellWands.configuration.record;
+package com.github.lukesky19.skySellWands.hooks;
 
-import java.util.List;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
 
-public record Locale(
-        String configVersion,
-        String prefix,
-        List<String> help,
-        String noPermission,
-        String unknownArgument,
-        String configReload,
-        String invalidPlayer,
-        String invalidUses,
-        String invalidAmount,
-        String givenWand,
-        String sellSuccess,
-        String containerInventoryEmpty,
-        String noItemsSold,
-        String wandUsedUp,
-        String noAccess) {}
+public interface ProtectionHook {
+    /**
+     * Can the Player open containers at the given Location?
+     * @param player   The Player who is attempting to access the container.
+     * @param location The Location of the container that is being accessed.
+     * @return true If the Player can open the container.
+     */
+    boolean canPlayerOpen(Player player, Location location);
+}

--- a/src/main/java/com/github/lukesky19/skySellWands/hooks/WorldGuardHook.java
+++ b/src/main/java/com/github/lukesky19/skySellWands/hooks/WorldGuardHook.java
@@ -1,0 +1,26 @@
+package com.github.lukesky19.skySellWands.hooks;
+
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
+import com.sk89q.worldguard.protection.flags.Flags;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+public class WorldGuardHook implements ProtectionHook {
+    final WorldGuard worldGuard = WorldGuard.getInstance();
+
+    @Override
+    public boolean canPlayerOpen(Player player, Location location) {
+        final var query = worldGuard.getPlatform().getRegionContainer().createQuery();
+        final var wgLocation = BukkitAdapter.adapt(location);
+        final var wgPlayer = WorldGuardPlugin.inst().wrapPlayer(player);
+        final var world = BukkitAdapter.adapt(location.getWorld());
+
+        if (WorldGuard.getInstance().getPlatform().getSessionManager().hasBypass(wgPlayer, world)) {
+            return true;
+        }
+
+        return query.testState(wgLocation, WorldGuardPlugin.inst().wrapPlayer(player), Flags.CHEST_ACCESS);
+    }
+}

--- a/src/main/java/com/github/lukesky19/skySellWands/listener/ItemSoldListener.java
+++ b/src/main/java/com/github/lukesky19/skySellWands/listener/ItemSoldListener.java
@@ -1,0 +1,19 @@
+package com.github.lukesky19.skySellWands.listener;
+
+import com.github.lukesky19.skySellWands.manager.WandKeys;
+import com.github.lukesky19.skyshop.event.ItemSoldEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.persistence.PersistentDataContainer;
+
+public class ItemSoldListener implements Listener {
+    @EventHandler
+    public void onItemSold(ItemSoldEvent event) {
+        PersistentDataContainer pdc = event.getItemStack().getItemMeta().getPersistentDataContainer();
+        // Check if it is a sellwand
+        if (pdc.has(WandKeys.USES.getKey())) {
+            // Cancel selling sell wands
+            event.setCancelled(true);
+        }
+    }
+}

--- a/src/main/java/com/github/lukesky19/skySellWands/listener/PlayerClickListener.java
+++ b/src/main/java/com/github/lukesky19/skySellWands/listener/PlayerClickListener.java
@@ -22,6 +22,7 @@ import com.github.lukesky19.skySellWands.configuration.manager.LocaleManager;
 import com.github.lukesky19.skySellWands.configuration.manager.SettingsManager;
 import com.github.lukesky19.skySellWands.configuration.record.Locale;
 import com.github.lukesky19.skySellWands.configuration.record.Settings;
+import com.github.lukesky19.skySellWands.manager.HookManager;
 import com.github.lukesky19.skySellWands.manager.WandKeys;
 import com.github.lukesky19.skylib.format.FormatUtil;
 import net.kyori.adventure.text.Component;
@@ -46,11 +47,13 @@ public class PlayerClickListener implements Listener {
     private final SkySellWands skySellWands;
     private final SettingsManager settingsManager;
     private final LocaleManager localeManager;
+    private final HookManager hookManager;
 
-    public PlayerClickListener(SkySellWands skySellWands, SettingsManager settingsManager, LocaleManager localeManager) {
+    public PlayerClickListener(SkySellWands skySellWands, SettingsManager settingsManager, LocaleManager localeManager, HookManager hookManager) {
         this.skySellWands = skySellWands;
         this.localeManager = localeManager;
         this.settingsManager = settingsManager;
+        this.hookManager = hookManager;
     }
 
     @EventHandler
@@ -80,6 +83,12 @@ public class PlayerClickListener implements Listener {
                     PersistentDataContainer pdc = itemMeta.getPersistentDataContainer();
                     // Check if it is a sellwand
                     if (pdc.has(WandKeys.USES.getKey())) {
+                        // Check if the player can access the container before selling
+                        if(hookManager.canNotOpen(player, block.getLocation())) {
+                            player.sendMessage(FormatUtil.format(locale.prefix() + locale.noAccess()));
+                            return;
+                        }
+
                         // Get the wand's uses
                         Integer uses = pdc.get(WandKeys.USES.getKey(), PersistentDataType.INTEGER);
                         if (uses == null) return; // Should never be null here, but just in-case we return if it is.

--- a/src/main/java/com/github/lukesky19/skySellWands/listener/PlayerClickListener.java
+++ b/src/main/java/com/github/lukesky19/skySellWands/listener/PlayerClickListener.java
@@ -98,7 +98,7 @@ public class PlayerClickListener implements Listener {
                         // Check if the container's inventory is not empty
                         if (!container.getInventory().isEmpty()) {
                             // Sell the container's inventory of items
-                            boolean result = skySellWands.getSkyShopAPI().sellInventory(player, inventory);
+                            boolean result = skySellWands.getSkyShopAPI().sellInventory(player, inventory, false);
 
                             // If at least one item was sold, send a success message
                             if (result) {

--- a/src/main/java/com/github/lukesky19/skySellWands/listener/PlayerClickListener.java
+++ b/src/main/java/com/github/lukesky19/skySellWands/listener/PlayerClickListener.java
@@ -22,6 +22,7 @@ import com.github.lukesky19.skySellWands.configuration.manager.LocaleManager;
 import com.github.lukesky19.skySellWands.configuration.manager.SettingsManager;
 import com.github.lukesky19.skySellWands.configuration.record.Locale;
 import com.github.lukesky19.skySellWands.configuration.record.Settings;
+import com.github.lukesky19.skySellWands.manager.HookManager;
 import com.github.lukesky19.skySellWands.manager.WandKeys;
 import com.github.lukesky19.skylib.format.FormatUtil;
 import net.kyori.adventure.text.Component;
@@ -46,11 +47,13 @@ public class PlayerClickListener implements Listener {
     private final SkySellWands skySellWands;
     private final SettingsManager settingsManager;
     private final LocaleManager localeManager;
+    private final HookManager hookManager;
 
-    public PlayerClickListener(SkySellWands skySellWands, SettingsManager settingsManager, LocaleManager localeManager) {
+    public PlayerClickListener(SkySellWands skySellWands, SettingsManager settingsManager, LocaleManager localeManager, HookManager hookManager) {
         this.skySellWands = skySellWands;
         this.localeManager = localeManager;
         this.settingsManager = settingsManager;
+        this.hookManager = hookManager;
     }
 
     @EventHandler
@@ -80,6 +83,12 @@ public class PlayerClickListener implements Listener {
                     PersistentDataContainer pdc = itemMeta.getPersistentDataContainer();
                     // Check if it is a sellwand
                     if (pdc.has(WandKeys.USES.getKey())) {
+                        // Check if the player can access the container before selling
+                        if(!hookManager.canPlayerOpen(player, block.getLocation())) {
+                            player.sendMessage(FormatUtil.format(locale.prefix() + locale.noAccess()));
+                            return;
+                        }
+
                         // Get the wand's uses
                         Integer uses = pdc.get(WandKeys.USES.getKey(), PersistentDataType.INTEGER);
                         if (uses == null) return; // Should never be null here, but just in-case we return if it is.

--- a/src/main/java/com/github/lukesky19/skySellWands/listener/ShopCreationListener.java
+++ b/src/main/java/com/github/lukesky19/skySellWands/listener/ShopCreationListener.java
@@ -1,0 +1,37 @@
+package com.github.lukesky19.skySellWands.listener;
+
+import com.ghostchu.quickshop.api.event.ShopPreCreateEvent;
+import com.github.lukesky19.skySellWands.manager.WandKeys;
+import com.github.lukesky19.skylib.format.FormatUtil;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+
+import java.util.Optional;
+
+public class ShopCreationListener implements Listener {
+    @EventHandler
+    public void onShopPreCreate(ShopPreCreateEvent event) {
+        // Get the player involved with the event
+        Optional<Player> optionalPlayer = event.getCreator().getBukkitPlayer();
+        if(optionalPlayer.isEmpty()) return;
+        Player player = optionalPlayer.get();
+
+        // Get the item the player's main hand
+        ItemStack handItem = player.getInventory().getItemInMainHand().clone();
+        // Get the item's ItemMeta
+        ItemMeta itemMeta = handItem.getItemMeta();
+        if(itemMeta != null) {
+            // Get the PersistentDataContainer of the item
+            PersistentDataContainer pdc = itemMeta.getPersistentDataContainer();
+            // Check if it is a sellwand
+            if (pdc.has(WandKeys.USES.getKey())) {
+                // Cancel the shop creation event
+                event.setCancelled(true, FormatUtil.format("Item is a sell wand."));
+            }
+        }
+    }
+}

--- a/src/main/java/com/github/lukesky19/skySellWands/manager/HookManager.java
+++ b/src/main/java/com/github/lukesky19/skySellWands/manager/HookManager.java
@@ -1,0 +1,77 @@
+/*
+    SkyHoppers adds upgradable hoppers that can suction items, transfer items wirelessly to linked containers.
+    Copyright (C) 2024  lukeskywlker19
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package com.github.lukesky19.skySellWands.manager;
+
+import com.github.lukesky19.skySellWands.SkySellWands;
+import com.github.lukesky19.skySellWands.hooks.BentoBoxHook;
+import com.github.lukesky19.skySellWands.hooks.ProtectionHook;
+import com.github.lukesky19.skySellWands.hooks.WorldGuardHook;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginManager;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class HookManager {
+    private final SkySellWands skySellWands;
+    private final List<ProtectionHook> protectionHooks = new ArrayList<>();
+
+    public HookManager(SkySellWands skySellWands) {
+        this.skySellWands = skySellWands;
+    }
+
+    public void reload() {
+        protectionHooks.clear();
+
+        final PluginManager pluginManager = skySellWands.getServer().getPluginManager();
+
+        Plugin bentoBox = pluginManager.getPlugin("BentoBox");
+        if(bentoBox != null && bentoBox.isEnabled()) {
+            protectionHooks.add(new BentoBoxHook());
+        }
+
+        Plugin worldGuard = pluginManager.getPlugin("WorldGuard");
+        if(worldGuard != null && worldGuard.isEnabled()) {
+            protectionHooks.add(new WorldGuardHook());
+        }
+    }
+
+    /**
+     * Can the Player open containers at the given Location?
+     * @param player   The Player who is attempting to access the container.
+     * @param location The Location of the container that is being accessed.
+     * @return true If the Player can open the container.
+     */
+    public boolean canPlayerOpen(Player player, Location location) {
+        for (ProtectionHook hook : this.protectionHooks) {
+            if(hook instanceof BentoBoxHook) {
+                if (hook.canPlayerOpen(player, location))
+                    return true;
+            } else {
+                if (!hook.canPlayerOpen(player, location))
+                    return false;
+            }
+
+
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/com/github/lukesky19/skySellWands/manager/HookManager.java
+++ b/src/main/java/com/github/lukesky19/skySellWands/manager/HookManager.java
@@ -1,0 +1,70 @@
+/*
+    SkyHoppers adds upgradable hoppers that can suction items, transfer items wirelessly to linked containers.
+    Copyright (C) 2024  lukeskywlker19
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+package com.github.lukesky19.skySellWands.manager;
+
+import com.github.lukesky19.skySellWands.SkySellWands;
+import com.github.lukesky19.skySellWands.hooks.BentoBoxHook;
+import com.github.lukesky19.skySellWands.hooks.ProtectionHook;
+import com.github.lukesky19.skySellWands.hooks.WorldGuardHook;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginManager;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class HookManager {
+    private final SkySellWands skySellWands;
+    private final List<ProtectionHook> protectionHooks = new ArrayList<>();
+
+    public HookManager(SkySellWands skySellWands) {
+        this.skySellWands = skySellWands;
+    }
+
+    public void reload() {
+        protectionHooks.clear();
+
+        final PluginManager pluginManager = skySellWands.getServer().getPluginManager();
+
+        Plugin bentoBox = pluginManager.getPlugin("BentoBox");
+        if(bentoBox != null && bentoBox.isEnabled()) {
+            protectionHooks.add(new BentoBoxHook());
+        }
+
+        Plugin worldGuard = pluginManager.getPlugin("WorldGuard");
+        if(worldGuard != null && worldGuard.isEnabled()) {
+            protectionHooks.add(new WorldGuardHook());
+        }
+    }
+
+    /**
+     * Can the Player open containers at the given Location?
+     * @param player   The Player who is attempting to access the container.
+     * @param location The Location of the container that is being accessed.
+     * @return true If the Player can open the container.
+     */
+    public boolean canNotOpen(Player player, Location location) {
+        for (ProtectionHook hook : this.protectionHooks) {
+            if (!hook.canPlayerOpen(player, location))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/src/main/resources/locale/en_US.yml
+++ b/src/main/resources/locale/en_US.yml
@@ -1,4 +1,4 @@
-config-version: 1.1.0
+config-version: 1.2.0
 prefix: "<aqua><bold>SkySellWands</bold></aqua><gray> ▪ </gray>"
 help:
     - "<aqua>SkySellWands is developed by <white><bold>lukeskywlker19</bold></white>.</aqua>"
@@ -21,3 +21,4 @@ sell-success: "<white>Sold all items in the container. Balance: <yellow><bal></y
 container-inventory-empty: "<red>No items were sold as the container's inventory is empty.</red>"
 no-items-sold: "<red>No items were sold as the container's inventory contained no items that could be sold.</red>"
 wand-used-up: "<dark_purple>POOF!</dark_purple> <red>Your sellwand ran out of uses.</red>"
+no-access: "<red>You do not have access to this container to sell the items inside.</red>"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,6 +3,7 @@ version: '1.0.0'
 main: com.github.lukesky19.skySellWands.SkySellWands
 api-version: '1.21'
 depend: [SkyLib, SkyShop, Vault]
+soft-depend: [QuickShop-Hikari]
 
 commands:
     skysellwands:


### PR DESCRIPTION
- Add checks to see if the player can open a container for BentoBox and WorldGuard before selling.
- Add listener to cancel Quickshop-Hikari shop creation if the item is a sell wand.
- Update dependencies in README.md.
- Upgrade SkyShop dependency to 2.0.0-Pre-Release-3 and add ItemSoldListener to cancel the selling of sell wands.